### PR TITLE
Fix elapsed time notification

### DIFF
--- a/app/src/main/java/com/example/timetracker/viewmodel/TimerVM.kt
+++ b/app/src/main/java/com/example/timetracker/viewmodel/TimerVM.kt
@@ -3,12 +3,10 @@ package com.example.timetracker.viewmodel
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.compose.foundation.layout.ContextualFlowRow
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
 import com.example.timetracker.data.ActivityEntry
 import androidx.lifecycle.viewModelScope
@@ -52,8 +50,8 @@ class TimerVM(private val repository: ActivityRepository) : ViewModel(){
      */
     fun start(context: Context) {
         if (!isRunning && name.isNotBlank()) {
-            onTimerStart(context, name)
             start = Instant.now()
+            onTimerStart(context, name)
             isRunning = true
             timerJob = viewModelScope.launch {
                 while (isRunning) {
@@ -95,7 +93,7 @@ class TimerVM(private val repository: ActivityRepository) : ViewModel(){
     }
 
     fun onTimerStart(context: Context, activityName: String) {
-        startNotification(context, activityName)
+        startNotification(context, activityName, start.epochSecond)
     }
 
     fun onTimerStop(context: Context) {

--- a/app/src/main/java/com/example/timetracker/worker/NotificationWorker.kt
+++ b/app/src/main/java/com/example/timetracker/worker/NotificationWorker.kt
@@ -22,7 +22,8 @@ class NotificationWorker (
     override suspend fun doWork(): Result {
         try {
             val activityName = inputData.getString("activityName") ?: "Activity"
-            val elapsedMinutes = inputData.getLong("elapsedMinutes", 0L)
+            val startTime = inputData.getLong("startTime", 0L)
+            val elapsedMinutes = ((System.currentTimeMillis() / 1000) - startTime) / 60
 
             val channelId = "timetracker_channel"
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -50,11 +51,14 @@ class NotificationWorker (
         return Result.success()
     }
 }
-fun startNotification(context: Context, activityName: String) {
+fun startNotification(context: Context, activityName: String, startTime: Long) {
     val workRequest = PeriodicWorkRequestBuilder<NotificationWorker>(
         15, TimeUnit.MINUTES
     )
-        .setInputData(workDataOf("activityName" to activityName))
+        .setInputData(workDataOf(
+            "activityName" to activityName,
+            "startTime" to startTime
+        ))
         .build()
 
     WorkManager.getInstance(context).enqueueUniquePeriodicWork(


### PR DESCRIPTION
## Summary
- pass activity start time to the periodic notification worker
- compute elapsed minutes inside the worker
- start timer before scheduling the notification

## Testing
- `./gradlew test --no-daemon` *(fails: `Could not find or load main class org.gradle.wrapper.GradleWrapperMain`)*

------
https://chatgpt.com/codex/tasks/task_e_685ad17429048325819abd51b8f08aea